### PR TITLE
Switch to Ed25519VerificationKey2018

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,7 +235,7 @@
     <section>
       <h2>Key Format</h2>
       <section>
-        <h3><dfn>Ed25519 208 Signature Verification Key</dfn></h3>
+        <h3><dfn>Ed25519 2018 Signature Verification Key</dfn></h3>
         <p>
           The key format is <a href="https://w3c-ccg.github.io/lds-ed25519-2018/">Ed25519VerificationKey2018</a>.
         </p>

--- a/index.html
+++ b/index.html
@@ -235,12 +235,12 @@
     <section>
       <h2>Key Format</h2>
       <section>
-        <h3><dfn>JCS JSON Web Key 2020</dfn></h3>
+        <h3><dfn>Ed25519 208 Signature Verification Key</dfn></h3>
         <p>
-          The key format <a href="https://github.com/w3c-ccg/lds-jws2020">JsonWebKey2020</a> is compatible.
+          The key format is <a href="https://w3c-ccg.github.io/lds-ed25519-2018/">Ed25519VerificationKey2018</a>.
         </p>
         <p>
-          A JCS JSON Web Key 2020 MUST contain a 
+          An Ed25519VerificationKey2018 using this suite MUST contain a 
           <code>publicKeyBase58</code> property.
         </p>
         <pre class="example" title="Example with publicKeyBase58">
@@ -249,7 +249,7 @@
   "publicKey": [
     {
       "id": "did:example:123#key-1",
-      "type": "JcsEd25519Key2020",
+      "type": "Ed25519VerificationKey2018",
       "controller": "did:example:123",
       "publicKeyBase58": "4CcKDtU1JNGi8U4D8Rv9CHzfmF7xzaxEAPFA54eQjRHF"
     }
@@ -344,7 +344,7 @@
   "publicKey": [
     {
       "id": "did:example:123#key-1",
-      "type": "JcsEd25519Key2020",
+      "type": "Ed25519VerificationKey2018",
       "controller": "did:example:123",
       "publicKeyBase58": "6b23ioXQSAayuw13PGFMCAKqjgqoLTpeXWCy5WRfw28c"
     }

--- a/signature-suite-impls/golang/proof/proof.go
+++ b/signature-suite-impls/golang/proof/proof.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	JCSVerificationType = "JcsEd25519Key2020"
+	JCSVerificationType = "Ed25519VerificationKey2018"
 	JCSSignatureType    = "JcsEd25519Signature2020"
 )
 

--- a/signature-suite-impls/java/signaturesuite/src/main/java/proof/Proof.java
+++ b/signature-suite-impls/java/signaturesuite/src/main/java/proof/Proof.java
@@ -24,7 +24,7 @@ import java.util.Date;
 
 public final class Proof {
 
-    public static final String JCS_VERIFICATION_TYPE = "JcsEd25519Key2020";
+    public static final String JCS_VERIFICATION_TYPE = "Ed25519VerificationKey2018";
     public static final String JCS_SIGNATURE_TYPE = "JcsEd25519Signature2020";
     public static final EdDSAParameterSpec ED_SPEC = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
 


### PR DESCRIPTION
The JCS Key type was unnecessary and confusing. To reduce the proliferation of additional key types I'd like to propose using the existing Ed25519VerificationKey2018 standard to generate JCS signatures.